### PR TITLE
[Feat] 대시보드 컨디션 리스트 하나로 반환 수정 

### DIFF
--- a/src/main/java/com/carelink/backend/dashboard/dto/ConditionSectionDto.java
+++ b/src/main/java/com/carelink/backend/dashboard/dto/ConditionSectionDto.java
@@ -3,5 +3,5 @@ package com.carelink.backend.dashboard.dto;
 import java.util.List;
 
 public record ConditionSectionDto(
-        List<ConditionDto> last7Days
+        List<Integer> moodScores
 ) {}


### PR DESCRIPTION
## 📌 관련 이슈


## ✨ 작업 내용
대시보드에서 컨디션 안에 date와 moodScore쌍 7개를 모두 반환하던 것에서 -> moodScores 배열 하나만 반환하도록 수정! 

## 📸 스크린샷


## 📚 참고 사항
그래프가 예쁘게 보이려면 더미데이터에 하루도 빠짐없이 넣어야겠습니다! 