### PR TITLE
[Feat] 완료한 인지훈련 여부가 뉴스 목록조회에서도 응답되게 수정

### DIFF
--- a/src/main/java/com/carelink/backend/training/news/dto/GeneralNewsDto.java
+++ b/src/main/java/com/carelink/backend/training/news/dto/GeneralNewsDto.java
@@ -12,4 +12,5 @@ public class GeneralNewsDto {
     private String thumbnailUrl;
     private int estimatedMinutes;
     private String previewSummary;
+    private boolean completed;
 }

--- a/src/main/java/com/carelink/backend/training/news/dto/RecommendedNewsDto.java
+++ b/src/main/java/com/carelink/backend/training/news/dto/RecommendedNewsDto.java
@@ -11,4 +11,5 @@ public class RecommendedNewsDto {
     private String title;
     private String thumbnailUrl;
     private int estimatedMinutes;
+    private boolean completed;
 }

--- a/src/main/java/com/carelink/backend/training/news/repository/CognitiveTrainingRepository.java
+++ b/src/main/java/com/carelink/backend/training/news/repository/CognitiveTrainingRepository.java
@@ -2,6 +2,8 @@ package com.carelink.backend.training.news.repository;
 
 import com.carelink.backend.training.news.entity.CognitiveTraining;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -29,4 +31,13 @@ public interface CognitiveTrainingRepository
             LocalDate start,
             LocalDate end
     );
+
+    // 오늘 기준으로 해당 유저가 완료한 뉴스 ID 목록
+    @Query("""
+        select ct.news.id
+        from CognitiveTraining ct
+        where ct.user.id = :userId
+          and ct.completed = true
+    """)
+    List<Long> findCompletedNewsIds(Long userId);
 }


### PR DESCRIPTION
## 📌 관련 이슈
closed #70 

## ✨ 작업 내용
- 기존 뉴스 목록조회에서는 인지훈련 완료 여부를 알 수 없었고, 기사를 선택해야만 응답이 왔음.
-> **완료한 인지훈련 여부가 뉴스 목록조회에서도 응답되게 수정**
- dto에 completed 필드 추가하여 완료여부 나타내도록 함 
- 레포지토리에 완료여부 조회하는 쿼리문 작성함 

## 📸 스크린샷


## 📚 참고 사항
